### PR TITLE
fix: Uppercase filename extension not supported in simple CLI format

### DIFF
--- a/pmlc-commands/src/main/java/dev/pmlc/commands/Start.java
+++ b/pmlc-commands/src/main/java/dev/pmlc/commands/Start.java
@@ -14,7 +14,7 @@ public class Start {
         init();
 
         int exitCode;
-        if ( args.length == 1 && args[0].endsWith ( ".pml" ) ) { // e.g. pmlc index.pml
+        if ( args.length == 1 && args[0].toLowerCase().endsWith ( ".pml" ) ) { // e.g. pmlc index.pml
             exitCode = PMLCommands.PMLToHTML ( args[0] );
         } else {
             exitCode = PMLCommands.runCommand ( args );


### PR DESCRIPTION
`index.PML` was loading with `pmlc p2h index.PML`, but not with the abbreviated syntax `pmlc index.PML`. This merge request should fix that.